### PR TITLE
Stringifying card number as per instructions

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -22,7 +22,7 @@ class CreditCardAPI < Sinatra::Base
     halt 400 unless card_number
 
     card = CreditCard.new(card_number, nil, nil, nil)
-    { "card": card_number,
+    { "card": "#{card_number}",
       "validated": card.validate_checksum
     }.to_json
   end


### PR DESCRIPTION
So made a minor change. The assignment instructions require 

``` ruby
{"card":"4024097178888052","validated":false}
# Previous card number wasn't returned as a string, but as integer
```
