### PR TITLE
Repeat data

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -78,8 +78,8 @@ class CreditCardAPI < Sinatra::Base
         redirect '/'
       rescue => e
         logger.error "FAIL EMAIL: #{e}"
-        flash[:error] = 'Could not send registration verification link: '\
-        'check email address'
+        msg = registration_error_msg(e)
+        flash[:error] = "Could not send registration verification link: #{msg}"
         redirect '/register'
       end
     else

--- a/app.rb
+++ b/app.rb
@@ -56,9 +56,9 @@ class CreditCardAPI < Sinatra::Base
       begin
         create_account_with_enc_token(token)
         flash[:notice] = 'Welcome! Your account has been created'
-      # rescue
-      #   flash[:error] = 'Your account could not be created. Your link has '\
-      #   'expired or is invalid'
+      rescue
+        flash[:error] = 'Your account could not be created. Your link has '\
+        'expired or is invalid'
       end
       redirect '/'
     else

--- a/app.rb
+++ b/app.rb
@@ -56,7 +56,8 @@ class CreditCardAPI < Sinatra::Base
       begin
         create_account_with_enc_token(token)
         flash[:notice] = 'Welcome! Your account has been created'
-      rescue
+      rescue => e
+        logger.error "FAIL Receipt: #{e}"
         flash[:error] = 'Your account could not be created. Your link has '\
         'expired or is invalid'
       end

--- a/app.rb
+++ b/app.rb
@@ -57,7 +57,7 @@ class CreditCardAPI < Sinatra::Base
         create_account_with_enc_token(token)
         flash[:notice] = 'Welcome! Your account has been created'
       rescue => e
-        logger.error "FAIL Receipt: #{e}"
+        logger.error "FAIL Return: #{e}"
         flash[:error] = 'Your account could not be created. Your link has '\
         'expired or is invalid'
       end

--- a/app.rb
+++ b/app.rb
@@ -56,9 +56,9 @@ class CreditCardAPI < Sinatra::Base
       begin
         create_account_with_enc_token(token)
         flash[:notice] = 'Welcome! Your account has been created'
-      rescue
-        flash[:error] = 'Your account could not be created. Your link has '\
-        'expired or is invalid'
+      # rescue
+      #   flash[:error] = 'Your account could not be created. Your link has '\
+      #   'expired or is invalid'
       end
       redirect '/'
     else

--- a/app.rb
+++ b/app.rb
@@ -122,7 +122,8 @@ class CreditCardAPI < Sinatra::Base
                             owner: "#{details_json['owner']}")
       halt 400 unless card.validate_checksum
       status 201 if card.save
-    rescue
+    rescue => e
+      logger.error(e)
       halt 410
     end
   end

--- a/helpers/creditcardapi_helper.rb
+++ b/helpers/creditcardapi_helper.rb
@@ -18,7 +18,7 @@ module CreditCardHelper
     def complete?
       list = instance_variables.map { |var| instance_variable_get var }
       list.all? do |var|
-        var && var.length > 0
+        var && var.strip.length > 0
       end
     end
   end

--- a/helpers/creditcardapi_helper.rb
+++ b/helpers/creditcardapi_helper.rb
@@ -51,7 +51,7 @@ module CreditCardHelper
   def create_payload(registration)
     payload = {}
     registration.instance_variables.map do |e|
-      payload[e] = registration.instance_variable_get e
+      payload["#{e}".gsub('@', '')] = registration.instance_variable_get e
     end
     payload
   end
@@ -116,6 +116,7 @@ module CreditCardHelper
     token = decrypt_message(enc_msg)
     payload = (JWT.decode token, ENV['MSG_KEY']).first
     reg = Registration.new(payload)
+    logger.info(payload)
     create_account_with_registration(reg)
   end
 end

--- a/helpers/creditcardapi_helper.rb
+++ b/helpers/creditcardapi_helper.rb
@@ -116,7 +116,6 @@ module CreditCardHelper
     token = decrypt_message(enc_msg)
     payload = (JWT.decode token, ENV['MSG_KEY']).first
     reg = Registration.new(payload)
-    logger.info(payload)
     create_account_with_registration(reg)
   end
 end

--- a/helpers/creditcardapi_helper.rb
+++ b/helpers/creditcardapi_helper.rb
@@ -53,6 +53,7 @@ module CreditCardHelper
     registration.instance_variables.map do |e|
       payload[e] = registration.instance_variable_get e
     end
+    payload
   end
 
   def repeat_data(registration)


### PR DESCRIPTION
#### Changes
- Usernames & email addresses already registered now fail immediately in registration with useful error messages.
- User input is checked for pure white space.
- Assignment to payload for JWT is refactored using instance variables; I don't trust the code but it works.
- Pony succeeds in sending mail whether email address is valid or not
  - Means error message "check email address." is currently useless.

**NOTE**: This is the branch deployed on heroku.
